### PR TITLE
Add option to include default styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-carousel-scroller",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "An application agnostic scrolling React component for controllable carousels",
   "main": "./carousel-scroller.js",
   "repository": "https://github.com/osartun/react-carousel-scroller",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-carousel-scroller",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "An application agnostic scrolling React component for controllable carousels",
   "main": "./carousel-scroller.js",
   "repository": "https://github.com/osartun/react-carousel-scroller",

--- a/src/carousel-scroller.js
+++ b/src/carousel-scroller.js
@@ -169,6 +169,21 @@ export default class CarouselScroller extends Component {
     return classNames({ scrolling }, this.props.className);
   }
 
+  getStyle() {
+    const base = {
+      position: 'absolute',
+      whiteSpace: 'nowrap',
+    };
+    const whileScrolling = this.state.scrolling ? {
+      userSelect: 'none',
+    } : null;
+    return Object.assign({},
+      base,
+      whileScrolling,
+      this.props.style
+    );
+  }
+
   render() {
     const { x, y } = this.state;
     return React.createElement(EasedScroller, {
@@ -179,7 +194,8 @@ export default class CarouselScroller extends Component {
       ref: this.setScrollerRef,
       onScrollStart: this.handleScrollStart,
       onScroll: this.handleScroll,
-      onScrollEnd: this.handleScrollEnd
+      onScrollEnd: this.handleScrollEnd,
+      style: this.getStyle(),
     }, this.props.children);
   }
 }
@@ -189,6 +205,7 @@ CarouselScroller.propTypes = {
   index: PropTypes.number,
   onChange: PropTypes.func,
   onEnd: PropTypes.func,
+  withStyle: PropTypes.bool,
 };
 
 CarouselScroller.defaultProps = {

--- a/src/eased-scroller.js
+++ b/src/eased-scroller.js
@@ -108,6 +108,10 @@ export default class EasedScroller extends Component {
     };
   }
 
+  renderStyle() {
+    return Object.assign({}, this.state.style, this.props.style);
+  }
+
   getRenderProps() {
     const props = _.omit(this.props, ['orientation', 'easeDuration']);
     return Object.assign({}, props, {
@@ -115,7 +119,7 @@ export default class EasedScroller extends Component {
       onScrollStart: this.handleScrollStart,
       onScroll: this.handleScroll,
       onScrollEnd: this.handleScrollEnd,
-      style: this.state.style,
+      style: this.renderStyle(),
     });
   }
 


### PR DESCRIPTION
* EasedScroller now only _adds_ its styling to the `style` attribute instead of _setting_ it / overriding potentially given styles
* `CarouselScroller` now includes a boolean `withStyling` prop that adds its default styling