### PR TITLE
Further bugfixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-carousel-scroller",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An application agnostic scrolling React component for controllable carousels",
   "main": "./carousel-scroller.js",
   "repository": "https://github.com/osartun/react-carousel-scroller",

--- a/src/carousel-scroller.js
+++ b/src/carousel-scroller.js
@@ -69,10 +69,12 @@ export default class CarouselScroller extends Component {
   }
 
   setScrollerRef(comp) {
-    this.el = {
-      scroller: comp.el,
-      container: comp.el.parentElement,
-    };
+    if (comp) {
+      this.el = {
+        scroller: comp.el,
+        container: comp.el.parentElement,
+      };
+    }
   }
 
   updateBounds() {

--- a/src/carousel-scroller.js
+++ b/src/carousel-scroller.js
@@ -69,12 +69,10 @@ export default class CarouselScroller extends Component {
   }
 
   setScrollerRef(comp) {
-    if (comp) {
-      this.el = {
-        scroller: comp.el,
-        container: comp.el.parentElement,
-      };
-    }
+    this.el = comp ? {
+      scroller: comp.el,
+      container: comp.el.parentElement,
+    } : {};
   }
 
   updateBounds() {

--- a/src/eased-scroller.js
+++ b/src/eased-scroller.js
@@ -20,6 +20,7 @@ export default class EasedScroller extends Component {
       acceleration: 0,
     };
     this.el = null;
+    this.rafId = 0;
     this.setRefEl = this.setRefEl.bind(this);
     this.handleScrollStart = this.handleScrollStart.bind(this);
     this.handleScroll = this.handleScroll.bind(this);
@@ -31,6 +32,12 @@ export default class EasedScroller extends Component {
     if (nextProps[orientation] !== this.props[orientation] &&
       !this.state.scrolling && !this.state.ending) {
       this.setState({ style: this.getStyle() });
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.rafId) {
+      raf.cancel(this.rafId);
     }
   }
 
@@ -80,7 +87,8 @@ export default class EasedScroller extends Component {
     const orientation = this.props.orientation;
     const endPos = this.calcPosAoT();
     this.setState({ style: this.getStyle() });
-    raf(() => {
+    this.rafId = raf(() => {
+      this.rafId = 0;
       if (typeof this.props.onScrollEnd === 'function') {
         const { direction, velocity, acceleration } = this.state;
         this.props.onScrollEnd(Object.assign({}, pos, {

--- a/src/eased-scroller.js
+++ b/src/eased-scroller.js
@@ -35,7 +35,9 @@ export default class EasedScroller extends Component {
   }
 
   setRefEl(comp) {
-    this.el = comp.el;
+    if (comp) {
+      this.el = comp.el;
+    }
   }
 
   handleScrollStart(pos, e) {

--- a/src/eased-scroller.js
+++ b/src/eased-scroller.js
@@ -38,6 +38,7 @@ export default class EasedScroller extends Component {
   componentWillUnmount() {
     if (this.rafId) {
       raf.cancel(this.rafId);
+      this.rafId = 0;
     }
   }
 

--- a/src/eased-scroller.js
+++ b/src/eased-scroller.js
@@ -35,9 +35,7 @@ export default class EasedScroller extends Component {
   }
 
   setRefEl(comp) {
-    if (comp) {
-      this.el = comp.el;
-    }
+    this.el = comp ? comp.el : null;
   }
 
   handleScrollStart(pos, e) {

--- a/src/scroller.js
+++ b/src/scroller.js
@@ -72,6 +72,7 @@ export default class Scroller extends Component {
     doc.removeEventListener('mousemove', this.handleScrollMove);
     doc.removeEventListener('touchend', this.handleScrollEnd, true);
     doc.removeEventListener('mouseup', this.handleScrollEnd, true);
+    this.doc = null;
 
     this.callHandler('onScrollEnd', {
       x: this.props.x,

--- a/src/scroller.js
+++ b/src/scroller.js
@@ -54,6 +54,10 @@ export default class Scroller extends Component {
   handleScrollMove(e) {
     if (e.touches && e.touches.length > 1) return;
 
+    if (e.buttons === 0) {
+      return this.handleScrollEnd(e);
+    }
+
     const { pageX, pageY } = (e.touches && e.touches[0]) || e;
 
     this.callHandler('onScroll', {

--- a/src/scroller.js
+++ b/src/scroller.js
@@ -39,7 +39,7 @@ export default class Scroller extends Component {
       startRelY: this.props.y,
     });
 
-    const doc = this.el.ownerDocument;
+    const doc = this.doc = this.el.ownerDocument;
     doc.addEventListener('touchmove', this.handleScrollMove);
     doc.addEventListener('mousemove', this.handleScrollMove);
     doc.addEventListener('touchend', this.handleScrollEnd, true);
@@ -67,7 +67,7 @@ export default class Scroller extends Component {
   }
 
   handleScrollEnd(e) {
-    const doc = this.el.ownerDocument;
+    const doc = this.doc;
     doc.removeEventListener('touchmove', this.handleScrollMove);
     doc.removeEventListener('mousemove', this.handleScrollMove);
     doc.removeEventListener('touchend', this.handleScrollEnd, true);


### PR DESCRIPTION
Due to recent changes and probably version upgrades, things worked differently than before.
With this PR

* A pending animation frame is cancelled when `EasedScroller` unmounts
* Null pointer exceptions are prevented when the `ref` is set to `null` during unmounting
* `handleScrollMove` checks if a mousebutton is pressed and aborts the scroll otherwise
* A reference to the document to which the event handlers are added is kept in case the document changes before the scroll ends