### PR TITLE
Prevent page scroll

### DIFF
--- a/docs/js/showcase/code-output.js
+++ b/docs/js/showcase/code-output.js
@@ -19,9 +19,9 @@ const CodeOutput = (props) => (
     orientation={${props.orientation}}
     className="scroller" ${
       props.listener !== 'none' ? `
-    onChange={onChangeHandler}
-      ` : ''
-    }
+    onChange={onChangeHandler}` : ''} ${
+      props.isPageScrollPrevented ? `
+    preventPageScroll` : ''}
   >
     {_.times(${props.nrOfItems}).map(() => (
       <div className="item" ${

--- a/docs/js/showcase/index.js
+++ b/docs/js/showcase/index.js
@@ -11,6 +11,7 @@ export default class Showcase extends Component {
       orientation: 'x',
       index: 0,
       isDiffSize: false,
+      isPageScrollPrevented: false,
       listener: 'basic'
     };
     this.onChangeOption = this.onChangeOption.bind(this);

--- a/docs/js/showcase/option-input.js
+++ b/docs/js/showcase/option-input.js
@@ -11,6 +11,7 @@ export default class OptionInput extends Component {
     this.onChangeOrientation = this.onChangeOrientation.bind(this);
     this.onChangeIndex = this.onChangeIndex.bind(this);
     this.onToggleDiffSize = this.onToggleDiffSize.bind(this);
+    this.onTogglePageScroll = this.onTogglePageScroll.bind(this);
     this.onChangeListener = this.onChangeListener.bind(this);
   }
 
@@ -39,6 +40,13 @@ export default class OptionInput extends Component {
     this.props.onChange({
       ...this.props,
       isDiffSize: e.target.checked
+    });
+  }
+
+  onTogglePageScroll(e) {
+    this.props.onChange({
+      ...this.props,
+      isPageScrollPrevented: e.target.checked
     });
   }
 
@@ -109,6 +117,17 @@ export default class OptionInput extends Component {
                 onChange={this.onToggleDiffSize}
               />
               Different sizes
+            </label>
+          </div>
+          <div className={css.wrapper}>
+            <label htmlFor={labelFor('preventPageScroll')}>
+              <input
+                id={labelFor('preventPageScroll')}
+                type="checkbox"
+                value={this.props.isPageScrollPrevented}
+                onChange={this.onTogglePageScroll}
+              />
+              Prevent page scroll
             </label>
           </div>
         </div>

--- a/docs/js/showcase/showcase-scroller.js
+++ b/docs/js/showcase/showcase-scroller.js
@@ -25,6 +25,7 @@ const ShowcaseScroller = (props) => (
       orientation={props.orientation}
       className={style.scroller}
       onChange={props.onChange}
+      preventPageScroll={props.isPageScrollPrevented}
     >
       {_.times(props.nrOfItems).map((u, i) => (
         <div

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-carousel-scroller",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "An application agnostic scrolling React component for controllable carousels",
   "main": "./carousel-scroller.js",
   "repository": "https://github.com/osartun/react-carousel-scroller",

--- a/src/carousel-scroller.js
+++ b/src/carousel-scroller.js
@@ -204,6 +204,7 @@ export default class CarouselScroller extends Component {
       onScroll: this.handleScroll,
       onScrollEnd: this.handleScrollEnd,
       style: this.getStyle(),
+      preventPageScroll: this.props.preventPageScroll,
     }, this.props.children);
   }
 }
@@ -216,6 +217,7 @@ CarouselScroller.propTypes = {
   onChange: PropTypes.func,
   onEnd: PropTypes.func,
   withStyle: PropTypes.bool,
+  preventPageScroll: PropTypes.bool,
 };
 
 CarouselScroller.defaultProps = {

--- a/src/scroller.js
+++ b/src/scroller.js
@@ -45,6 +45,11 @@ export default class Scroller extends Component {
     doc.addEventListener('touchend', this.handleScrollEnd, true);
     doc.addEventListener('mouseup', this.handleScrollEnd, true);
 
+    if (this.props.preventPageScroll) {
+      this.prevOverflow = doc.body.style.overflow;
+      doc.body.style.overflow = 'hidden';
+    }
+
     this.callHandler('onScrollStart', {
       x: this.props.x,
       y: this.props.y,
@@ -72,6 +77,10 @@ export default class Scroller extends Component {
     doc.removeEventListener('mousemove', this.handleScrollMove);
     doc.removeEventListener('touchend', this.handleScrollEnd, true);
     doc.removeEventListener('mouseup', this.handleScrollEnd, true);
+
+    if (this.props.preventPageScroll) {
+      doc.body.style.overflow = this.prevOverflow;
+    }
     this.doc = null;
 
     this.callHandler('onScrollEnd', {
@@ -153,6 +162,7 @@ Scroller.propTypes = {
   onScrollStart: PropTypes.func,
   onScroll: PropTypes.func,
   onScrollEnd: PropTypes.func,
+  preventPageScroll: PropTypes.bool,
   x: PropTypes.number,
   y: PropTypes.number,
   disableOnWheel: PropTypes.bool,


### PR DESCRIPTION
Dragging the carousel and moving it could also lead to moving / scrolling the whole page with it. This is a problem especially on mobile.
This PR introduces a new property called `preventPageScroll`. When set, the body gets a `overflow: hidden` style for the duration of the scroll. Afterwards it's set back to the previous `overflow` value if there was one.

![prevent-page-scroll](https://user-images.githubusercontent.com/1381730/29240251-7cbdad9e-7f61-11e7-8737-ae3af787423f.gif)
